### PR TITLE
Bug squashing for remarks and weird LI6400 files

### DIFF
--- a/R/Li6400Import.R
+++ b/R/Li6400Import.R
@@ -1,5 +1,5 @@
 #' Imports Licor 6400 photosynthesis system files.
-#' 
+#'
 #' @param file Filename of the Li6400 text file (usually .csv or .tsv)
 #' @param sep Character string to identify columns in the Li6400 file. Default is "\\t" for tab-separated. Use "," for comma-separated.
 #' @return Returns a list with two items: a data.frame with the imported file without the remarks, and a data.frame with the remarks and a new vector RemarkRow that provides the original row number of the remark before the split of data and remarks.
@@ -8,7 +8,7 @@
 Li6400Import <- function(file, sep = "\t") {
 
   x <- readLines(file)
-  
+
   # add the date to the HHMMSS vector - by default the file only has the time of day
   # grab date from second row in file
   the.date <- x[2]
@@ -16,41 +16,63 @@ Li6400Import <- function(file, sep = "\t") {
 
   # Licor uses non standard weekday names!
   the.date <- gsub("Thr", "Thu", the.date)
-  
+
   the.date <- as.POSIXct(the.date,
-               format = "%a %b %d %Y %H:%M:%S")
+                         format = "%a %b %d %Y %H:%M:%S")
 
   # look for phrase "$STARTOFDATA$" to get row after which import should start
   start.data <- grep("STARTOFDATA", x)
-  
-  y <- utils::read.csv(file, 
-                skip = start.data,
-                #sep = "\t",
-                sep = sep,
-                na.strings = c("NA", ""))
+
+  y <- utils::read.csv(file,
+                       skip = start.data,
+                       #sep = "\t",
+                       sep = sep,
+                       na.strings = c("NA", ""))
 
   # assemble full date based on date in file header, as Li6400 only records time in the HHMMSS field
   the.day <- format(the.date, "%Y-%m-%d")
   y$HHMMSS <- as.character(y$HHMMSS)
   y$HHMMSS[!is.na(y$HHMMSS)] <- paste(the.day, y$HHMMSS[!is.na(y$HHMMSS)], sep = " ")
-  
+
   y$HHMMSS <- as.POSIXct(y$HHMMSS)
-  
+
   # move Remarks out of the way, they are provided separately
   # get information on the rows that the remarks were in
+  # also need to retrieve the first remark
+
+  # figure out where the remark is based on the assumption it is after the constants
+  start.remark <- grep("Const=", x)
+  start.remark.1 <- start.remark[length(start.remark)]
+
+  # read in just that one remark
+  remarks.1 <- utils::read.csv(file,
+                               sep = sep,
+                               skip = start.remark.1,
+                               nrows = 1,
+                               header = FALSE,
+                               na.strings = c("NA", ""))
+  # format it to match the original coding
+  remarks.1$Remarks <- remarks.1$V1
+  remarks.1$V1 <- NULL
+  remarks.1$RemarkRow <- 1
+
+  # get the other remarks
   remarks <- y[is.na(y$FTime), ]
   remarks.row <- which(is.na(y$FTime))
   remarks$RemarkRow <- remarks.row
-  
+
+
   # rename to avoid overwriting Obs in case the remarks will be merged back with the data later
   names(remarks) <- gsub("^Obs", "Remarks", names(remarks))
-  
+
   # only keep row information and remarks
   remarks <- remarks[, names(remarks) %in% c("Remarks", "RemarkRow")]
-  
+
+  # add in first remark
+  remarks <- rbind(remarks, remarks.1)
+
   y <- y[!is.na(y$FTime), ]
   out <- list(data = y,
               remarks = remarks)
   return(out)
 }
-

--- a/R/Li6400Import.R
+++ b/R/Li6400Import.R
@@ -23,10 +23,8 @@ Li6400Import <- function(file, sep = "\t") {
   # look for phrase "$STARTOFDATA$" to get row after which import should start
   start.data <- grep("STARTOFDATA", x)
 
-
-
   if (length(start.data) > 1) {
-    message("File has multiple starts. Obs likely will not be unique. Use Li6400RemarkReshuffle with caution.")
+    message(paste0(file, "has multiple starts. Obs likely will not be unique. Use Li6400RemarkReshuffle with caution."))
 
     connect <- file(file, "r")
     start.data.many <- 1

--- a/R/Li6400Import.R
+++ b/R/Li6400Import.R
@@ -23,15 +23,36 @@ Li6400Import <- function(file, sep = "\t") {
   # look for phrase "$STARTOFDATA$" to get row after which import should start
   start.data <- grep("STARTOFDATA", x)
 
+
+
   if (length(start.data) > 1) {
     message("File has multiple starts. Obs likely will not be unique. Use Li6400RemarkReshuffle with caution.")
+
+    connect <- file(file, "r")
+    start.data.many <- 1
+    while (TRUE) {
+      line = readLines(connect, n = 1)
+      if (line == "$STARTOFDATA$" ) {
+        break
+      }
+      start.data.many = start.data.many + 1
+    }
+    close(connect)
+
+    y <- utils::read.csv(file,
+                         skip = start.data.many,
+                         #sep = "\t",
+                         sep = sep,
+                         na.strings = c("NA", ""))
   }
 
-  y <- utils::read.csv(file,
-                       skip = start.data,
-                       #sep = "\t",
-                       sep = sep,
-                       na.strings = c("NA", ""))
+  else{
+    y <- utils::read.csv(file,
+                         skip = start.data,
+                         #sep = "\t",
+                         sep = sep,
+                         na.strings = c("NA", ""))
+  }
 
   # assemble full date based on date in file header, as Li6400 only records time in the HHMMSS field
   the.day <- format(the.date, "%Y-%m-%d")

--- a/R/Li6400Import.R
+++ b/R/Li6400Import.R
@@ -24,7 +24,7 @@ Li6400Import <- function(file, sep = "\t") {
   start.data <- grep("STARTOFDATA", x)
 
   if (length(start.data) > 1) {
-    message(paste0(file, "has multiple starts. Obs likely will not be unique. Use Li6400RemarkReshuffle with caution."))
+    message(paste0(file, " has multiple starts. Obs likely will not be unique. Use Li6400RemarkReshuffle with caution."))
 
     connect <- file(file, "r")
     start.data.many <- 1

--- a/R/Li6400Import.R
+++ b/R/Li6400Import.R
@@ -23,6 +23,10 @@ Li6400Import <- function(file, sep = "\t") {
   # look for phrase "$STARTOFDATA$" to get row after which import should start
   start.data <- grep("STARTOFDATA", x)
 
+  if (length(start.data) > 1) {
+    message("File has multiple starts. Obs likely will not be unique. Use Li6400RemarkReshuffle with caution.")
+  }
+
   y <- utils::read.csv(file,
                        skip = start.data,
                        #sep = "\t",

--- a/R/Li6400RemarksReshuffle.R
+++ b/R/Li6400RemarksReshuffle.R
@@ -23,7 +23,7 @@ Li6400RemarkReshuffle <- function(remark) {
   stopifnot(names(remark$remarks) %in% c("Remarks", "RemarkRow"))
 
   # create a continuous sequence from first to last remark row
-  full.seq <- seq(from = min(remark$remarks$RemarkRow), to = max(remark$remarks$RemarkRow), by = 1)
+  full.seq <- seq(from = min(remark$remarks$RemarkRow), to = max(as.numeric(remark$data$Obs)), by = 1)
 
   # merge full sequence with remarks
   r <- merge(as.data.frame(full.seq), remark$remarks,

--- a/R/Li6400RemarksReshuffle.R
+++ b/R/Li6400RemarksReshuffle.R
@@ -1,5 +1,5 @@
 FillForward <- function(x) {
-  #' Fill NA elements in a vector using the last non-NA entry without using \code{zoo:na.locf} 
+  #' Fill NA elements in a vector using the last non-NA entry without using \code{zoo:na.locf}
   #'
   #' Fills NA elements in a vector using the last non-NA element preceeding each missing element. Follows \href{https://stat.ethz.ch/pipermail/r-help/2008-July/169195.html}{this suggestion}.
   #'
@@ -19,17 +19,17 @@ Li6400RemarkReshuffle <- function(remark) {
   #' @return Data.frame with a new vector ForwardFilledRemarks in which gaps between remarks are filled with the last, previous remark.
   #' @seealso \code{\link{Li6400Import}}
   #' @export
-  
-  stopifnot(names(remark) %in% c("Remarks", "RemarkRow"))
+
+  stopifnot(names(remark$remarks) %in% c("Remarks", "RemarkRow"))
 
   # create a continuous sequence from first to last remark row
-  full.seq <- seq(from = min(remark$RemarkRow), to = max(remark$RemarkRow), by = 1)
+  full.seq <- seq(from = min(remark$remarks$RemarkRow), to = max(remark$remarks$RemarkRow), by = 1)
 
   # merge full sequence with remarks
-  r <- merge(as.data.frame(full.seq), remark,
-           by.x = "full.seq",
-           by.y = "RemarkRow",
-           all.x = TRUE)
+  r <- merge(as.data.frame(full.seq), remark$remarks,
+             by.x = "full.seq",
+             by.y = "RemarkRow",
+             all.x = TRUE)
   names(r) <- gsub("full.seq", "Row", names(r))
   r$ForwardFilledRemarks <- FillForward(r$Remarks)
   return(r)


### PR DESCRIPTION
Improving the functionality of this very helpful package so that it works more smoothly and with different kinds of LICOR 6400 weirdness.

* Previously, any remark made before data were collected was dropped. That first remark is now imported and assigned to any obs made before the second remark.
* Sometimes the LI6400 generates multiple data headers and starts to the data. Previously, this broke the read.csv function. Now the file will be read in, but with a warning message so that the user knows that it creates a potential one-to-many issue when joining remarks to the data. (Some day I hope to find a way to fix the one-to-many issue as well but I haven't figured it out yet.)